### PR TITLE
Implementar targets iniciales (help, tools, test) en Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: help tools test clean
+
+help:
+	@echo ""
+	@echo "Targets disponibles:"
+	@echo "  help   - Muestra esta ayuda."
+	@echo "  tools  - Verifica si las herramientas necesarias (curl, dig, bats) están instaladas."
+	@echo "  test   - Ejecuta las pruebas unitarias con Bats."
+	@echo "  clean  - Limpia archivos generados (implementaremos en proximos sprints)."
+
+# Definción de targets
+tools:
+	@echo "Verificando herramientas necesarias..."
+	@command -v bash >/dev/null 2>&1 || { echo >&2 "Error: 'bash' no está instalado. Abortando."; exit 1; }
+	@command -v curl >/dev/null 2>&1 || { echo >&2 "Error: 'curl' no está instalado. Abortando."; exit 1; }
+	@command -v dig >/dev/null 2>&1 || { echo >&2 "Error: 'dig' no está instalado. Abortando."; exit 1; }
+	@command -v bats >/dev/null 2>&1 || { echo >&2 "Error: 'bats' no está instalado. Abortando."; exit 1; }
+	@echo "Todas las herramientas necesarias están instaladas. ✅"
+test:
+	@echo "Ejecutando pruebas con Bats..."
+	@bats tests/
+clean:


### PR DESCRIPTION
¿Qué se hizo?
Se implementaron los targets iniciales (help, tools y test) en el Makefile.

¿Por qué se hizo?
Para preparar el entorno de trabajo del equipo. El target help mejora la usabilidad, tools verifica las dependencias necesarias y test prepara el proyecto para las pruebas automatizadas.

¿Cómo se hizo?
Se modificó el Makefile existente para incluir la lógica de cada uno de estos targets, y se creó el script para la verificación de herramienta

Evidencia de Funcionamiento
make help
<img width="479" height="146" alt="Captura de pantalla 2025-09-15 003129" src="https://github.com/user-attachments/assets/0f48eeaa-9c0e-4733-b430-f8db84b84015" />

make tools
<img width="483" height="54" alt="Captura de pantalla 2025-09-15 002827" src="https://github.com/user-attachments/assets/e52c624a-f2e7-434a-a874-49c259559494" />

make test
<img width="498" height="77" alt="Captura de pantalla 2025-09-15 002821" src="https://github.com/user-attachments/assets/759e31e3-3052-409e-94bb-2174f1fc8960" />


Checklist de Revisión
<img width="861" height="121" alt="Captura de pantalla 2025-09-15 002640" src="https://github.com/user-attachments/assets/f2b7777e-e15a-4844-84c5-a3aae8450818" />
