### PR TITLE
feat: Añadir lógica inicial y config por entorno

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+## Variables de entorno de configuración
+
+| Variable       | Descripción                                 | Valor por defecto   | Ejemplo           |
+|----------------|---------------------------------------------|---------------------|-------------------|
+| TARGET_HOST    | Host o IP de destino para la configuración  | localhost           | 192.168.1.10      |
+| TARGET_PORT    | Puerto de destino para la conexión          | 8080                | 443               |
+| ENVIRONMENT    | Entorno de despliegue (dev, prod, etc.)     | development         | production        |
+
+### Uso
+
+Puedes definir las variables de entorno antes de ejecutar el script.  
+Si no se definen, se usarán los valores por defecto.
+
+```bash
+export TARGET_HOST=192.168.1.10
+export TARGET_PORT=443
+export ENVIRONMENT=production
+./src/configurador.sh
+```

--- a/src/configurador.sh
+++ b/src/configurador.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+# Leer variables de entorno con valores por defecto
+TARGET_HOST="${TARGET_HOST:-localhost}"
+TARGET_PORT="${TARGET_PORT:-8080}"
+ENVIRONMENT="${ENVIRONMENT:-development}"
+
+echo "Configurando entorno..."
+echo "TARGET_HOST: $TARGET_HOST"
+echo "TARGET_PORT: $TARGET_PORT"
+echo "ENVIRONMENT: $ENVIRONMENT"


### PR DESCRIPTION
¿Qué se hizo?
Se implementó la lógica inicial del script configurador.sh para la configuración automática de entornos DevOps, incluyendo la lectura de variables de entorno con valores por defecto.

¿Por qué se hizo?
Para cumplir con el Sprint 1 del proyecto, estableciendo la base del script y permitiendo la configuración flexible mediante variables de entorno, facilitando la adaptación a diferentes entornos y necesidades.

¿Cómo se hizo?
*Se activó el modo robusto de Bash.
*Se añadieron tres variables de entorno.
*Se imprimen los valores configurados para verificación.

Evidencia de Funcionamiento

bash configurador.sh

<img width="673" height="177" alt="1" src="https://github.com/user-attachments/assets/c3f67cc0-ef58-4d13-803f-3ee31bbbb733" />
