### PR TITLE
Parche de emergencia en la prueba de ejecución de configurador.sh

### DIFF
--- a/tests/sprint1_core.bats
+++ b/tests/sprint1_core.bats
@@ -3,14 +3,14 @@
 CONFIG_PATH="./src/configurador.sh"
 
 @test "Script: 'configurador.sh' es ejecutable..." {
-    if [! -x "$CONFIG_PATH" ]; then
+    if [[ ! -x "$CONFIG_PATH" ]]; then
         echo "Error: configurador.sh no tiene permiso de ejecución" >&2
         false
     else
         echo "configurador.sh tiene permiso de ejecución" >&3
     fi
     
-    run bash "$CONFIG_PATH"
+    run "$CONFIG_PATH"
     if [ $status -ne 0 ]; then
         echo "Error: configurador.sh devolvió estado $status" >&2
         false


### PR DESCRIPTION
Reparacion de prueba .bats
Adicion de espacio en la linea 6, antes causaba que no se detectara si configurador.sh tenia permisos de ejecucion (siempre lo marcaba positivo)
Cambio en linea 13: corre el archivo sin anteponer bash (ignoraba si tenia o no permisos de ejecucion)