### PR TITLE
Implementación de servicio de systemd para el configurador

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-echo "out/" >> .gitignore
-echo "dist/" >> .gitignore
+out/
+dist/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help tools test clean
+.PHONY: help tools test clean install
 
 help:
 	@echo ""
@@ -16,7 +16,33 @@ tools:
 	@command -v dig >/dev/null 2>&1 || { echo >&2 "Error: 'dig' no está instalado. Abortando."; exit 1; }
 	@command -v bats >/dev/null 2>&1 || { echo >&2 "Error: 'bats' no está instalado. Abortando."; exit 1; }
 	@echo "Todas las herramientas necesarias están instaladas. ✅"
-test:
+
+test: tools
 	@echo "Ejecutando pruebas con Bats..."
 	@bats tests/
+
+run: tools
+	@echo "Ejecutando el configurador.sh..."
+	@bash src/configurador.sh
+
 clean:
+	@echo "Limpiando archivos generados..."
+	@rm -rf out/*.log out/*.txt out/
+
+install:
+	@echo "Crear el directorio de trabajo="
+	@echo "   sudo mkdir -p /opt/proyecto-devops-grupo6"
+	@echo ""	
+	@echo "Copiar el script principal y darle permisos="
+	@echo "   sudo cp src/configurador.sh /usr/local/bin/configurador.sh"
+	@echo "   sudo chmod +x /usr/local/bin/configurador.sh"
+	@echo ""
+	@echo "Copiar los archivos de datos necesarios="
+	@echo "	  sudo cp -r out/ /opt/proyecto-devops-grupo6/"
+	@echo ""
+	@echo "Copiar el archivo de servicio de systemd="
+	@echo "   sudo cp systemd/configurador.service /etc/systemd/system/configurador.service"
+	@echo ""	
+	@echo "Configuración de systemd y habilitando el servicio="
+	@echo "   sudo systemctl daemon-reload"
+	@echo "   sudo systemctl enable configurador.service"	

--- a/config/archivo_de_usuarios.txt
+++ b/config/archivo_de_usuarios.txt
@@ -1,0 +1,4 @@
+juan:Juan Perez:user
+pedro:Pedro Garcia:user
+maria:Maria Lopez:admin
+ana:Ana Torres:admin

--- a/src/configurador.sh
+++ b/src/configurador.sh
@@ -1,20 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-# Leer variables de entorno con valores por defecto
-TARGET_HOST="${TARGET_HOST:-localhost}"
-TARGET_PORT="${TARGET_PORT:-8080}"
-ENVIRONMENT="${ENVIRONMENT:-development}"
-
-echo "Configurando entorno..."
-echo "TARGET_HOST: $TARGET_HOST"
-echo "TARGET_PORT: $TARGET_PORT"
-echo "ENVIRONMENT: $ENVIRONMENT"
-
-log_archivo="out/dns_check.log"
-txt_archivos="out/*.txt"
-
 cleanup() {
+
+    local log_dir="out"
+    local log_archivo="$log_dir/dns_check.log"
+
     echo "Limpiando archivos temporales..."
     if [ -f "$log_archivo" ]; then
         rm -f "$log_archivo"
@@ -23,22 +14,12 @@ cleanup() {
         echo "El archivo de log no existe."
     fi
 
-    if ls $txt_archivos 1> /dev/null 2>&1; then
-        rm -f $txt_archivos
-        echo "Archivos .txt eliminados."
-    else
-        echo "No se encontraron archivos .txt."
-    fi
-
     echo "Archivos temporales eliminados."
 }
 
-mkdir -p "$(dirname "$log_archivo")"
-
-trap 'cleanup' EXIT 
-
 pipeline_de_unix() {
-    archivo="out/archivo_de_usuarios.txt"  
+    #local archivo="out/archivo_de_usuarios.txt"  
+    local archivo="config/archivo_de_usuarios.txt"
 
     if [ ! -f "$archivo" ]; then
         echo "El $archivo no existe."
@@ -52,4 +33,23 @@ pipeline_de_unix() {
     echo "Proceso completado."
 
 }
-pipeline_de_unix
+
+main() {
+
+    trap 'cleanup' EXIT  
+
+    TARGET_HOST="${TARGET_HOST:-localhost}"
+    TARGET_PORT="${TARGET_PORT:-8080}"
+    ENVIRONMENT="${ENVIRONMENT:-development}"
+
+    local log_dir="out"
+    mkdir -p "$log_dir"
+
+    echo "Configuración en proceso..."
+    echo "TARGET_HOST: $TARGET_HOST"
+    echo "TARGET_PORT: $TARGET_PORT"
+    echo "ENVIRONMENT: $ENVIRONMENT"
+
+    pipeline_de_unix
+}
+main "$@"

--- a/systemd/configurador.service
+++ b/systemd/configurador.service
@@ -1,0 +1,13 @@
+[Unit]
+Description= Servicio para ejecutar el configurador automatico DevOps
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/configurador.sh
+User=root
+Group=root
+WorkingDirectory=/opt/proyecto-devops-grupo6
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/sprint1_core.bats
+++ b/tests/sprint1_core.bats
@@ -3,14 +3,14 @@
 CONFIG_PATH="./src/configurador.sh"
 
 @test "Script: 'configurador.sh' es ejecutable..." {
-    if [[ ! -x "$CONFIG_PATH" ]]; then
+    if [ ! -x "$CONFIG_PATH" ]; then
         echo "Error: configurador.sh no tiene permiso de ejecución" >&2
         false
     else
         echo "configurador.sh tiene permiso de ejecución" >&3
     fi
     
-    run "$CONFIG_PATH"
+    run bash "$CONFIG_PATH"
     if [ $status -ne 0 ]; then
         echo "Error: configurador.sh devolvió estado $status" >&2
         false


### PR DESCRIPTION
### Refactorización del Script y Añadido de `systemd`

#### **Decisiones Relevantes**

* **Refactorización del Script Principal (`src/configurador.sh`)**
    * **Decisión:** Se reestructuró todo el script para usar una función `main()` como punto de entrada.
    * **Justificación:** Esto mejora drásticamente la legibilidad y el mantenimiento. Permite controlar el flujo de ejecución de manera clara, definir el `trap` en un alcance lógico y encapsular la lógica principal

* **Creación del Archivo de Servicio (`systemd/configurador.service`)**
    * **Decisión:** Se añadió un archivo de unidad de `systemd` para gestionar el script como un servicio del sistema.
    * **Justificación:** Este es un paso fundamental para la automatización a nivel de sistema operativo. Permite que el script sea iniciado, detenido y habilitado para el arranque por `systemd`.

* **Actualización del `Makefile`**
    * **Decisión:** Se añadieron los targets `run` e `install` y se crearon dependencias (`test` y `run` ahora dependen de `tools`).
 

#### **Cambios Adicionales**
* **`config/archivo_de_usuarios.txt`:** Se añadió un archivo de configuración con datos de ejemplo para que el pipeline tenga una fuente a analizar
* **`src/configurador.sh`:**
    * El pipeline ahora lee desde `config/` en lugar de `out/`.
    * La función `cleanup` fue ajustada para no borrar los archivos de resultados `.txt`.