### PR TITLE
Implementar funciones de verificación de red para DNS y HTTP

### DIFF
--- a/config/archivo_de_usuarios_ejemplo.txt
+++ b/config/archivo_de_usuarios_ejemplo.txt
@@ -1,6 +1,3 @@
-#ELIMINAR ESTA Y LA SIGUIENTE LINEA SI SE QUIERE USAR COMO ARCHIVO DE PRUEBA
-#RENOMBRAR A archivo_de_usuarios.txt
-juan:Juan Perez:user
-pedro:Pedro Garcia:user
-maria:Maria Lopez:admin
-ana:Ana Torres:admin
+herbert:Heriberto G.:user
+gil:Gilberto Leonardo:admin
+walter:Walter G.:admin

--- a/src/configurador.sh
+++ b/src/configurador.sh
@@ -17,9 +17,49 @@ cleanup() {
     echo "Archivos temporales eliminados."
 }
 
+verificar_dns() {
+    local dominio="$1"
+    local log_file="out/dns_check.log"
+    
+    echo ""
+    echo "Vericando DNS para el dominio: '$dominio'..."
+
+    log_file= dig "$dominio"
+
+    local ip_resuelta
+
+    ip_resuelta=$(dig +short "$dominio")
+
+    if [ -z "$ip_resuelta" ]; then
+        echo "Error: No se pudo resolver el dominio $dominio">&2
+        return 1
+    else
+        echo "El dominio $dominio se resolvió a la IP: $ip_resuelta"
+        return 0
+    fi
+}
+
+verificar_http() {
+    local dominio="$1"
+    local codigo_esperado="$2"
+    echo ""
+    echo "Verificando HTTP para la URL: $dominio..."
+
+
+    local codigo_real
+    codigo_real=$(curl -s -o /dev/null -w "%{http_code}" "$dominio")
+
+    if [ "$codigo_real" -eq "$codigo_esperado" ]; then
+        echo "Ok: La URL $dominio devolvió el código de estado HTTP $codigo_real" >&2
+    else
+        echo "Error:  Se esperaba el código '$codigo_esperado' pero se recibió '$codigo_real' de la URL '$dominio'." 
+        exit 1
+    fi
+}
+
 pipeline_de_unix() {
     #local archivo="out/archivo_de_usuarios.txt"  
-    local archivo="config/archivo_de_usuarios.txt"
+    local archivo="config/archivo_de_usuarios_ejemplo.txt"
 
     if [ ! -f "$archivo" ]; then
         echo "El $archivo no existe."
@@ -34,22 +74,65 @@ pipeline_de_unix() {
 
 }
 
+verificar_certificado_tls() {
+    local DOMINIO=$1
+    if [ -z "$DOMINIO" ]; then
+        echo "ADVERTENCIA: dominio no proporcionado verificar el certificado."
+        return
+    fi 
+    
+    echo "INFO: Verificando certificado TLS para $DOMINIO..."
+
+    local FECHA_EXP=$(echo | openssl s_client -connect $DOMINIO:443 2>/dev/null | openssl x509 -noout -enddate | cut -d= -f2)
+
+    if [ -z "$FECHA_EXP" ]; then
+        echo "ERROR: No se pudo obtener la fecha de expiración del certificado para $DOMINIO" >&2
+        return 1
+    fi
+
+    local EXP_SEGUNDOS=$(date -d "$FECHA_EXP" +%s)
+    local HOY_SEGUNDOS=$(date +%s)
+
+    if [ "$EXP_SEGUNDOS" -lt "$HOY_SEGUNDOS" ]; then
+        echo "ERROR: El certificado TLS para $DOMINIO ha expirado el $(date -d "@$EXP_SEGUNDOS")" >&2
+    else
+        local DIAS_RESTANTES=$(( ($EXP_SEGUNDOS - $HOY_SEGUNDOS) / 86400 ))
+        echo "OK: El certificado para $DOMINIO es válido. Expira en $DIAS_RESTANTES días."
+    fi
+
+}
+
 main() {
 
     trap 'cleanup' EXIT  
 
-    TARGET_HOST="${TARGET_HOST:-localhost}"
-    TARGET_PORT="${TARGET_PORT:-8080}"
-    ENVIRONMENT="${ENVIRONMENT:-development}"
+    local TARGET_HOST="${TARGET_HOST:-localhost}"
+    local TARGET_PORT="${TARGET_PORT:-8080}"
+    local ENVIRONMENT="${ENVIRONMENT:-development}"
+
+    local CHECK_DOMAIN="${CHECK_DOMAIN:-"google.com"}"
+    local CHECK_URL="${CHECK_URL:-"https://www.google.com"}"
+    local EXPECTED_STATUS="${EXPECTED_STATUS:-200}"
+    
+    
 
     local log_dir="out"
     mkdir -p "$log_dir"
 
+    echo ""
     echo "Configuración en proceso..."
     echo "TARGET_HOST: $TARGET_HOST"
     echo "TARGET_PORT: $TARGET_PORT"
     echo "ENVIRONMENT: $ENVIRONMENT"
+    echo ""    
 
     pipeline_de_unix
+    
+    echo ""
+    echo ""
+    echo "Verificaciones de red..."
+    verificar_dns "$CHECK_DOMAIN"
+    verificar_http "$CHECK_URL" "$EXPECTED_STATUS"
+    verificar_certificado_tls "$CHECK_DOMAIN"
 }
 main "$@"


### PR DESCRIPTION
### Resumen de Cambios: Implementación de Verificaciones de Red

Este Pull Request introduce las funcionalidades de verificación de red requeridas para el Sprint 3, integrando chequeos de DNS, HTTP y TLS en el flujo principal del `configurador.sh`.

#### **Decisiones Relevantes**

* **Implementación de Funciones de Red (`configurador.sh`)**
    * **Decisión:** Se añadieron tres nuevas funciones modulares: `verificar_dns`, `verificar_http` y `verificar_certificado_tls`.
    * **Justificación:** Crear funciones separadas para cada tipo de chequeo (DNS, HTTP, TLS) hace que el código sea más limpio, fácil de leer y reutilizable. Cada función tiene una única responsabilidad, lo que simplifica las pruebas y la depuración.

* **Integración en `main()` (`configurador.sh`)**
    * **Decisión:** Las nuevas funciones de red se llaman desde la función `main()`, y los dominios/URLs a verificar se controlan mediante variables de entorno (`CHECK_DOMAIN`, `CHECK_URL`).
    * **Justificación:** Esto permite que el comportamiento de las verificaciones sea configurable desde el exterior sin modificar el código, siguiendo el principio de 12-Factor App. Además, centraliza la orquestación de tareas en la función `main`, manteniendo un flujo de ejecución claro.

#### **Cambios Adicionales**

* **`config/archivo_de_usuarios_ejemplo.txt`:** Se actualizaron los datos del archivo de usuarios de ejemplo.
* **`src/configurador.sh`:**
    * Se ajustó la ruta del archivo de usuarios que lee el pipeline.
    * Se convirtieron las variables de `main()` en locales para mejorar el encapsulamiento.